### PR TITLE
Update server tasks, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ just decrypt
 just encrypt
 ```
 
+#### Note
+
+If you are running anything with a separate "-service-dep", you may need to run a base install, with just the MASH core things (traefik, docker, etc) first to get the dependencies needed for the "-service-dep" to work. After that, enable everything and have the "-service-dep" run first.
+
 ### Old, to be updated
 - Setup Ubuntu 18.04
 	- `ansible-playbook -l coruscant -i initial-config/hosts -u root initial-config/setup_ubuntu1804/playbook.yml`

--- a/hosts
+++ b/hosts
@@ -2,7 +2,7 @@
 localhost ansible_connection=local
 
 [servers]
-taris ansible_user=root
+taris ansible_user=root become=true
 
 [mash_servers]
 [mash_servers:children]

--- a/roles/server/tasks/shell.yml
+++ b/roles/server/tasks/shell.yml
@@ -1,6 +1,13 @@
+- name: Update package index
+  become: true
+  ansible.builtin.apt:
+    update_cache: yes
+  when: ansible_facts['os_family'] == "Debian"
+
 - name: Install standard shell related packages. Used by other tasks
   become: true
   ansible.builtin.package:
     name:
       - sudo
+      - gnupg2
     state: present

--- a/roles/server/tasks/system.yml
+++ b/roles/server/tasks/system.yml
@@ -1,6 +1,6 @@
 - name: Set a hostname
   ansible.builtin.hostname:
-    name: '{{ ansible_host }}'
+    name: '{{ inventory_hostname }}'
 
 - name: Set timezone to Pacific Time
   community.general.timezone:

--- a/roles/server/tasks/user.yml
+++ b/roles/server/tasks/user.yml
@@ -1,6 +1,7 @@
 - name: Create user
   ansible.builtin.user:
     name: matthew
+    shell: /bin/bash
 
 - name: Make sure we have a 'wheel' group
   ansible.builtin.group:


### PR DESCRIPTION
- Set terminal to bash
- Update package index of Debian based systems
- gnupg2
- Use inventory_hostname for hostname
- Add note about initial setup requiring an extra step